### PR TITLE
Relocated dependency

### DIFF
--- a/contester_proto/Blobs.pb.go
+++ b/contester_proto/Blobs.pb.go
@@ -4,7 +4,7 @@
 
 package contester_proto
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/contester_proto/Contester.pb.go
+++ b/contester_proto/Contester.pb.go
@@ -4,7 +4,7 @@
 
 package contester_proto
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/contester_proto/Execution.pb.go
+++ b/contester_proto/Execution.pb.go
@@ -4,7 +4,7 @@
 
 package contester_proto
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/contester_proto/Local.pb.go
+++ b/contester_proto/Local.pb.go
@@ -4,7 +4,7 @@
 
 package contester_proto
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/contester_proto/proto_helpers.go
+++ b/contester_proto/proto_helpers.go
@@ -2,7 +2,7 @@ package contester_proto
 
 import (
 	"bytes"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"compress/zlib"
 	"crypto/sha1"
 	"io"

--- a/service/exec.go
+++ b/service/exec.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/runlib/contester_proto"
 	"github.com/contester/runlib/subprocess"
 )

--- a/service/service.go
+++ b/service/service.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"code.google.com/p/goconf/conf"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/runlib/contester_proto"
 	"github.com/contester/runlib/platform"
 	"github.com/contester/runlib/subprocess"

--- a/tools/stat.go
+++ b/tools/stat.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"github.com/contester/runlib/contester_proto"
 	"os"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 func StatFile(name string, hash_it bool) (*contester_proto.FileStat, error) {


### PR DESCRIPTION
"code.google.com/p/goprotobuf/proto" has moved to "github.com/golang/protobuf/proto"
Updated go import paths to reflect this change.